### PR TITLE
doap: update to the latest specification

### DIFF
--- a/doap.xml
+++ b/doap.xml
@@ -37,9 +37,6 @@
 
     <os>Haiku</os>
 
-    <!-- TODO: Categories are URIs, find a better location for them. -->
-    <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-xmpp"/>
-    <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-jabber"/>
     <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-client"/>
 
     <maintainer>
@@ -63,51 +60,46 @@
 	<!-- TODO <implements rdf:resource="https://xmpp.org/rfcs/rfc7590.html"/> -->
 	<!-- TODO: https://github.com/HaikuArchives/Jabber4Haiku/issues/29 -->
     <!--<implements rdf:resource="https://xmpp.org/rfcs/rfc5122.html"/>-->
-
-    <xmpp:software>
-        <xmpp:Client>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0030.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.22.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0045.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.22.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0048.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                    <xmpp:since>1.22.0</xmpp:since>
-					<xmpp:note>retrieval only, autojoin only</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0060.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.13.5</xmpp:version>
-                    <xmpp:since>1.22.0</xmpp:since>
-                    <xmpp:note>only user nickname</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0092.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                    <xmpp:since>1.22.0</xmpp:since>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-        </xmpp:Client>
-    </xmpp:software>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0030.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.22.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0045.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.22.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0048.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+            <xmpp:since>1.22.0</xmpp:since>
+			<xmpp:note>retrieval only, autojoin only</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0060.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.13.5</xmpp:version>
+            <xmpp:since>1.22.0</xmpp:since>
+            <xmpp:note>only user nickname</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0092.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+            <xmpp:since>1.22.0</xmpp:since>
+        </xmpp:SupportedXep>
+    </implements>
 
     <release>
         <Version>


### PR DESCRIPTION
The xmpp-doap extension has be simplified to only expose the
SupportedXep class and its children properties, as well as categories,
and reuses DOAP to the maximum.