### PR TITLE
Small changes and sentence-casing of GUI strings

### DIFF
--- a/jabber/BlabberSettings.cpp
+++ b/jabber/BlabberSettings.cpp
@@ -31,7 +31,7 @@ BlabberSettings::BlabberSettings(const char *filename)
        SetDefaultTagsValue();
 	} else if (status == FileXMLReader::FILE_CORRUPTED) {
 		// back up their settings
-		ModalAlertFactory::Alert("We regret to inform you that your settings file has been corrupted.  It has been replaced with a fresh copy.", "Oh, darn!");
+		ModalAlertFactory::Alert("We regret to inform you that your settings file has been corrupted. It has been replaced with a fresh copy.", "Oh, darn!");
 		SetDefaultTagsValue();
 	}
 }

--- a/jabber/CustomStatusWindow.cpp
+++ b/jabber/CustomStatusWindow.cpp
@@ -39,7 +39,7 @@ CustomStatusWindow *CustomStatusWindow::Instance() {
 
 
 CustomStatusWindow::CustomStatusWindow(BRect frame)
-	: BWindow(frame, "Create a Custom Status",
+	: BWindow(frame, "Create a custom status",
 		B_TITLED_WINDOW,
 		B_AUTO_UPDATE_SIZE_LIMITS |
 		B_NOT_ZOOMABLE |
@@ -50,9 +50,9 @@ CustomStatusWindow::CustomStatusWindow(BRect frame)
 
 	_away = new BRadioButton("status", "Away", NULL);
 
-	_xa = new BRadioButton("status", "Extended Away", NULL);
+	_xa = new BRadioButton("status", "Extended away", NULL);
 
-	_dnd = new BRadioButton("status", "Do Not Disturb", NULL);
+	_dnd = new BRadioButton("status", "Do not disturb", NULL);
 
 
 	BStringView *query = new BStringView(NULL, "Please provide your detailed status:");
@@ -67,7 +67,7 @@ CustomStatusWindow::CustomStatusWindow(BRect frame)
 		_handle->SetText("I'm at my computer.");
 	}
 
-	BButton *cancel = new BButton("cancel", "Nevermind", new BMessage(JAB_CANCEL));
+	BButton *cancel = new BButton("cancel", "Cancel", new BMessage(JAB_CANCEL));
 	cancel->SetTarget(this);
 
 	BButton *ok = new BButton("ok", "OK", new BMessage(JAB_OK));

--- a/jabber/JRoster.cpp
+++ b/jabber/JRoster.cpp
@@ -159,7 +159,7 @@ JRoster::handleItemSubscribed(const gloox::JID&)
 			sprintf(buffer, "Your subscription request was accepted by %s!", asker);
 		}
 		
-		ModalAlertFactory::Alert(buffer, "Hooray!");
+		ModalAlertFactory::Alert(buffer, "OK");
 #endif
 }
 
@@ -321,8 +321,8 @@ JRoster::handleSubscriptionRequest(const gloox::JID& JID, const string& reason)
 	// TODO this uses a synchrnous alert so the gloox thread will be blocked (no other message can
 	// be sent or received) until the alert is answered by the user. Instead we should use
 	// asynchronous mode
-	answer = ModalAlertFactory::Alert(message.String(), "No, I prefer privacy.",
-		"Yes, grant them my presence!");
+	answer = ModalAlertFactory::Alert(message.String(), "No, I prefer privacy",
+		"Yes, grant them my presence");
 
 	// send back the response
 	if (answer == 1) {
@@ -342,7 +342,7 @@ JRoster::handleUnsubscriptionRequest(const gloox::JID&, const string&)
 	printf("%s\n", __PRETTY_FUNCTION__);
 #if 0
 		sprintf(buffer, "%s no longer wishes to know your online status.", asker);
-		ModalAlertFactory::NonModalAlert(buffer, "I feel so unloved.");
+		ModalAlertFactory::NonModalAlert(buffer, "I feel so unloved");
 #endif
 	return false;
 }

--- a/jabber/JabberSpeak.cpp
+++ b/jabber/JabberSpeak.cpp
@@ -156,7 +156,7 @@ void JabberSpeak::OnTag(XMLEntity *entity) {
 						sprintf(buffer, "You were refused registration information from an unidentifying Jabber service for the following reason:\n\n%s", entity->Child("error")->Data());
 					}
 
-					ModalAlertFactory::Alert(buffer, "Oh, well.", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
+					ModalAlertFactory::Alert(buffer, "Oh, well", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
 				}
 
 				// for errors on registration
@@ -168,7 +168,7 @@ void JabberSpeak::OnTag(XMLEntity *entity) {
 						sprintf(buffer, "Your registration attempt was refused by an unidentifying Jabber service for the following reason:\n\n%s", entity->Child("error")->Data());
 					}
 
-					ModalAlertFactory::Alert(buffer, "Oh, well.", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
+					ModalAlertFactory::Alert(buffer, "Oh, well", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
 				}
 
 				// for errors on unregistration
@@ -180,7 +180,7 @@ void JabberSpeak::OnTag(XMLEntity *entity) {
 						sprintf(buffer, "You were refused unregistration information from an unidentifying Jabber service for the following reason:\n\n%s", entity->Child("error")->Data());
 					}
 
-					ModalAlertFactory::Alert(buffer, "Oh, well.", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
+					ModalAlertFactory::Alert(buffer, "Oh, well", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
 				}
 			}
 		}
@@ -208,7 +208,7 @@ void JabberSpeak::OnTag(XMLEntity *entity) {
 						sprintf(buffer, "Your registration attempt with an unidentifying Jabber service has been accepted.");
 					}
 
-					ModalAlertFactory::Alert(buffer, "Yeah!", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
+					ModalAlertFactory::Alert(buffer, "OK", NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT); 
 				}
 			}
 		}
@@ -696,7 +696,7 @@ JabberSpeak::handleVCard(const gloox::JID& jid, const gloox::VCard* vcard)
 	if (!vcard->tz().empty())
 		message.AddString("Timezone", vcard->tz().c_str());
 	if (!vcard->sortstring().empty())
-		message.AddString("Sort String", vcard->sortstring().c_str());
+		message.AddString("Sort string", vcard->sortstring().c_str());
 	if (!vcard->org().name.empty())
 		message.AddString("Organization", vcard->org().name.c_str());
 	for (std::string unit: vcard->org().units)

--- a/jabber/LoginPreferencesView.cpp
+++ b/jabber/LoginPreferencesView.cpp
@@ -44,13 +44,13 @@ void LoginPreferencesView::AttachedToWindow() {
 	frame.bottom = frame.top + 48.0;
 
 	_surrounding_groupchat = new BBox(frame, NULL, B_FOLLOW_ALL);
-	_surrounding_groupchat->SetLabel("Group Chat Options");
+	_surrounding_groupchat->SetLabel("Group chat options");
 
 	frame.OffsetBy(0.0, frame.Height() + 10.0);
 	frame.bottom = frame.top + 68.0;
 
 	_surrounding_chatlog = new BBox(frame, NULL, B_FOLLOW_ALL);
-	_surrounding_chatlog->SetLabel("Chat Log Options");
+	_surrounding_chatlog->SetLabel("Chat log options");
 
 	frame = _surrounding->Bounds();
 	
@@ -96,7 +96,7 @@ void LoginPreferencesView::AttachedToWindow() {
 	frame.right  = frame.left + 375.0;
 	frame.bottom = frame.top + 18;
 
-	_name = new BTextControl(frame, NULL, "Channel Name:", BlabberSettings::Instance()->Data("channel-name"), NULL);
+	_name = new BTextControl(frame, NULL, "Channel name:", BlabberSettings::Instance()->Data("channel-name"), NULL);
 
 	_surrounding_options->AddChild(_show_timestamp);
 	_surrounding_options->AddChild(_show_all_chat);
@@ -111,7 +111,7 @@ void LoginPreferencesView::AttachedToWindow() {
 	frame.right  = frame.left + 375.0;
 	frame.bottom = frame.top + 18;
 
-	_autoopen_chatlog = new BCheckBox(frame, NULL, "Autoopen of Chat Log.", NULL);	
+	_autoopen_chatlog = new BCheckBox(frame, NULL, "Auto-open chat log", NULL);	
 	_autoopen_chatlog->SetValue(BlabberSettings::Instance()->Tag("autoopen-chatlog"));
 	
 	frame.OffsetBy(0.0, 19.0);

--- a/jabber/PreferencesWindow.cpp
+++ b/jabber/PreferencesWindow.cpp
@@ -35,7 +35,7 @@ PreferencesWindow *PreferencesWindow::Instance() {
 }
 
 PreferencesWindow::PreferencesWindow()
-	: BWindow(BRect(0, 0, 0, 0), "User Preferences", B_TITLED_WINDOW, B_NOT_RESIZABLE | B_NOT_ZOOMABLE) {
+	: BWindow(BRect(0, 0, 0, 0), "User settings", B_TITLED_WINDOW, B_NOT_RESIZABLE | B_NOT_ZOOMABLE) {
 
 	// add self to message family
 	MessageRepeater::Instance()->AddTarget(this);
@@ -97,14 +97,14 @@ PreferencesWindow::PreferencesWindow()
 	rect.OffsetBy(235.0, _tab_strip->Bounds().Height() + 20.0);
 	rect.right = rect.left + 92;
 
-	_cancel = new BButton(rect, "cancel", "Ignore Changes", new BMessage(JAB_CANCEL), B_FOLLOW_RIGHT | B_FOLLOW_BOTTOM);
+	_cancel = new BButton(rect, "cancel", "Cancel", new BMessage(JAB_CANCEL), B_FOLLOW_RIGHT | B_FOLLOW_BOTTOM);
 	_cancel->SetTarget(this);
 
 	// ok button
 	rect.OffsetBy(100.0, 0.0);
 	rect.right = rect.left + 92;
 
-	_ok = new BButton(rect, "ok", "Save Changes", new BMessage(JAB_OK),  B_FOLLOW_RIGHT | B_FOLLOW_BOTTOM);
+	_ok = new BButton(rect, "ok", "OK", new BMessage(JAB_OK),  B_FOLLOW_RIGHT | B_FOLLOW_BOTTOM);
 	_ok->MakeDefault(true);
 	_ok->SetTarget(this);
 

--- a/jabber/RosterView.cpp
+++ b/jabber/RosterView.cpp
@@ -55,10 +55,10 @@ void RosterView::AttachedToWindow() {
 	_popup = new BPopUpMenu(NULL, false, false);
 
 		_chat_item         = new BMenuItem("Chat" B_UTF8_ELLIPSIS, new BMessage(JAB_OPEN_CHAT));
-		_message_item      = new BMenuItem("Send Message" B_UTF8_ELLIPSIS, new BMessage(JAB_OPEN_MESSAGE));
-		_change_user_item  = new BMenuItem("Edit Buddy", new BMessage(JAB_OPEN_EDIT_BUDDY_WINDOW));
-		_remove_user_item  = new BMenuItem("Remove Buddy", new BMessage(JAB_REMOVE_BUDDY));
-		_user_info_item    = new BMenuItem("Get Buddy Info", new BMessage(JAB_USER_INFO));
+		_message_item      = new BMenuItem("Send message" B_UTF8_ELLIPSIS, new BMessage(JAB_OPEN_MESSAGE));
+		_change_user_item  = new BMenuItem("Edit buddy", new BMessage(JAB_OPEN_EDIT_BUDDY_WINDOW));
+		_remove_user_item  = new BMenuItem("Remove buddy", new BMessage(JAB_REMOVE_BUDDY));
+		_user_info_item    = new BMenuItem("Get buddy info", new BMessage(JAB_USER_INFO));
 
 		_presence          = new BMenu("Presence");
 
@@ -80,10 +80,10 @@ void RosterView::AttachedToWindow() {
 
 	// create top level lists
 	AddItem(_online  = new RosterSuperitem("Online"));
-	AddItem(_unaccepted = new RosterSuperitem("Pending Presence"));
-	AddItem(_unknown = new RosterSuperitem("No Presence"));
+	AddItem(_unaccepted = new RosterSuperitem("Pending presence"));
+	AddItem(_unknown = new RosterSuperitem("No presence"));
 	AddItem(_offline = new RosterSuperitem("Offline"));
-	AddItem(_transports = new RosterSuperitem("Live Transports"));
+	AddItem(_transports = new RosterSuperitem("Live transports"));
 	AddItem(_bookmarks = new RosterSuperitem("Group chats"));
 
 	// make maps (BUGBUG better way to do two-way map?)
@@ -441,11 +441,11 @@ void RosterView::UpdatePopUpMenu() {
 		_chat_item->SetEnabled(false);
 		_message_item->SetEnabled(false);
 
-		sprintf(buffer, "Edit Buddy");
+		sprintf(buffer, "Edit buddy");
 		_change_user_item->SetLabel(buffer);
 		_change_user_item->SetEnabled(false);
 
-		sprintf(buffer, "Remove Buddy");
+		sprintf(buffer, "Remove buddy");
 		_remove_user_item->SetLabel(buffer);
 		_remove_user_item->SetEnabled(false);
 

--- a/jabber/SendTalkWindow.cpp
+++ b/jabber/SendTalkWindow.cpp
@@ -58,9 +58,9 @@ SendTalkWindow::SendTalkWindow(gloox::Message::MessageType type)
 
 	_surrounding = new BBox(rect, NULL);
 	if (_type == gloox::Message::Groupchat) {
-		_surrounding->SetLabel("Select Group Chat Properties");
+		_surrounding->SetLabel("Select group chat properties");
 	} else {
-		_surrounding->SetLabel("Select a User");
+		_surrounding->SetLabel("Select a user");
 	}
 
 	rect.OffsetTo(B_ORIGIN);
@@ -69,7 +69,7 @@ SendTalkWindow::SendTalkWindow(gloox::Message::MessageType type)
 
 	// chat service
 	_chat_services_selection = new BPopUpMenu("Jabber");
-	_chat_services = new BMenuField(rect, "chat_services", "Online Service: ", _chat_services_selection);
+	_chat_services = new BMenuField(rect, "chat_services", "Online service: ", _chat_services_selection);
 	_chat_services->SetDivider(_chat_services->Divider() - 33);
 	BMenuItem *default_item = new BMenuItem("Jabber", new BMessage(AGENT_MENU_CHANGED_TO_JABBER));
 	_chat_services_selection->AddItem(default_item);
@@ -88,7 +88,7 @@ SendTalkWindow::SendTalkWindow(gloox::Message::MessageType type)
 	}
 
 	if (_type == gloox::Message::Groupchat) {
-		_handle = new BTextControl(rect, "handle", "Room Name: ", NULL, NULL, B_FOLLOW_ALL_SIDES);
+		_handle = new BTextControl(rect, "handle", "Room name: ", NULL, NULL, B_FOLLOW_ALL_SIDES);
 	} else {
 		_handle = new BTextControl(rect, "handle", "Jabber ID: ", NULL, NULL, B_FOLLOW_ALL_SIDES);
 	}
@@ -122,7 +122,7 @@ SendTalkWindow::SendTalkWindow(gloox::Message::MessageType type)
 	rect.OffsetBy(135.0, 24.0);
 	rect.right = rect.left + 65;
 
-	BButton *cancel = new BButton(rect, "cancel", "Nevermind", new BMessage(JAB_CANCEL));
+	BButton *cancel = new BButton(rect, "cancel", "Cancel", new BMessage(JAB_CANCEL));
 	cancel->SetTarget(this);
 
 	// ok button
@@ -132,14 +132,14 @@ SendTalkWindow::SendTalkWindow(gloox::Message::MessageType type)
 	BButton *ok = new BButton(rect, "ok", "", new BMessage(JAB_OK));
 
 	if (_type == gloox::Message::Normal) {
-		SetTitle("Send New Message");
-		ok->SetLabel("Send Message");
+		SetTitle("Send new message");
+		ok->SetLabel("Send message");
 	} else if (_type == gloox::Message::Chat) {
-		SetTitle("Start New Chat");
-		ok->SetLabel("Start Chat");
+		SetTitle("Start new chat");
+		ok->SetLabel("Start chat");
 	} else if (_type == gloox::Message::Groupchat) {
-		SetTitle("Start New Group Chat");
-		ok->SetLabel("Start Chat");
+		SetTitle("Start new group chat");
+		ok->SetLabel("Start chat");
 	}
 
 	ok->MakeDefault(true);
@@ -221,8 +221,8 @@ bool SendTalkWindow::ValidateGroupRoom() {
 	char buffer[4096];
 
 	if (!strcmp(_handle->Text(), "")) {
-		sprintf(buffer, "Please specify the group's roomname.");
-		ModalAlertFactory::Alert(buffer, "Oops!");
+		sprintf(buffer, "Please specify the group's room name.");
+		ModalAlertFactory::Alert(buffer, "OK");
 		_handle->MakeFocus(true);
 
 		return false;
@@ -230,7 +230,7 @@ bool SendTalkWindow::ValidateGroupRoom() {
 
 	if (!strcmp(_name->Text(), "")) {
 		sprintf(buffer, "Please specify your handle.");
-		ModalAlertFactory::Alert(buffer, "Oops!");
+		ModalAlertFactory::Alert(buffer, "OK");
 		_handle->MakeFocus(true);
 
 		return false;
@@ -244,7 +244,7 @@ string SendTalkWindow::ValidateUser() {
 
 	if (!strcmp(_handle->Text(), "")) {
 		sprintf(buffer, "Please specify a user's handle.");
-		ModalAlertFactory::Alert(buffer, "Oops!");
+		ModalAlertFactory::Alert(buffer, "OK");
 		_handle->MakeFocus(true);
 
 		return "";

--- a/jabber/SoundPreferencesView.cpp
+++ b/jabber/SoundPreferencesView.cpp
@@ -44,13 +44,13 @@ void SoundPreferencesView::AttachedToWindow() {
 	rect.bottom = rect.top + 211.0;
 
 	_surrounding = new BBox(rect, NULL, B_FOLLOW_ALL);
-	_surrounding->SetLabel("Associated Sound Events");
+	_surrounding->SetLabel("Associated sound events");
 
 	rect.OffsetBy(0.0, rect.Height() + 10.0);
 	rect.bottom = rect.top + 75.0;
 	
 	_surrounding_options = new BBox(rect, NULL, B_FOLLOW_ALL);
-	_surrounding_options->SetLabel("Other Sound Options");
+	_surrounding_options->SetLabel("Other sound options");
 	
 	rect = _surrounding->Bounds();
 	
@@ -77,7 +77,7 @@ void SoundPreferencesView::AttachedToWindow() {
 	
 	_new_chat_selection->AddSeparatorItem();
 	_new_chat_selection->AddItem(new BMenuItem("<none>", new BMessage(JAB_NO_NEW_MESSAGE_SOUND)));
-	_new_chat_selection->AddItem(new BMenuItem("Other...", new BMessage(JAB_PICK_NEW_MESSAGE_SOUND)));
+	_new_chat_selection->AddItem(new BMenuItem("Other" B_UTF8_ELLIPSIS, new BMessage(JAB_PICK_NEW_MESSAGE_SOUND)));
 
 	if (sound->NewMessageSound().empty()) {
 		_new_chat_selection->FindItem("<none>")->SetMarked(true);
@@ -106,7 +106,7 @@ void SoundPreferencesView::AttachedToWindow() {
 	
 	_message_selection->AddSeparatorItem();
 	_message_selection->AddItem(new BMenuItem("<none>", new BMessage(JAB_NO_MESSAGE_SOUND)));
-	_message_selection->AddItem(new BMenuItem("Other...", new BMessage(JAB_PICK_MESSAGE_SOUND)));
+	_message_selection->AddItem(new BMenuItem("Other" B_UTF8_ELLIPSIS, new BMessage(JAB_PICK_MESSAGE_SOUND)));
 
 	if (sound->MessageSound().empty()) {
 		_message_selection->FindItem("<none>")->SetMarked(true);
@@ -135,7 +135,7 @@ void SoundPreferencesView::AttachedToWindow() {
 	
 	_now_online_selection->AddSeparatorItem();
 	_now_online_selection->AddItem(new BMenuItem("<none>", new BMessage(JAB_NO_USER_ONLINE_SOUND)));
-	_now_online_selection->AddItem(new BMenuItem("Other...", new BMessage(JAB_PICK_USER_ONLINE_SOUND)));
+	_now_online_selection->AddItem(new BMenuItem("Other" B_UTF8_ELLIPSIS, new BMessage(JAB_PICK_USER_ONLINE_SOUND)));
 
 	if (sound->UserOnlineSound().empty()) {
 		_now_online_selection->FindItem("<none>")->SetMarked(true);
@@ -164,7 +164,7 @@ void SoundPreferencesView::AttachedToWindow() {
 	
 	_now_offline_selection->AddSeparatorItem();
 	_now_offline_selection->AddItem(new BMenuItem("<none>", new BMessage(JAB_NO_USER_OFFLINE_SOUND)));
-	_now_offline_selection->AddItem(new BMenuItem("Other...", new BMessage(JAB_PICK_USER_OFFLINE_SOUND)));
+	_now_offline_selection->AddItem(new BMenuItem("Other" B_UTF8_ELLIPSIS, new BMessage(JAB_PICK_USER_OFFLINE_SOUND)));
 
 	if (sound->UserOfflineSound().empty()) {
 		_now_offline_selection->FindItem("<none>")->SetMarked(true);
@@ -193,7 +193,7 @@ void SoundPreferencesView::AttachedToWindow() {
 	
 	_alert_selection->AddSeparatorItem();
 	_alert_selection->AddItem(new BMenuItem("<none>", new BMessage(JAB_NO_ALERT_SOUND)));
-	_alert_selection->AddItem(new BMenuItem("Other...", new BMessage(JAB_PICK_ALERT_SOUND)));
+	_alert_selection->AddItem(new BMenuItem("Other" B_UTF8_ELLIPSIS, new BMessage(JAB_PICK_ALERT_SOUND)));
 
 	if (sound->AlertSound().empty()) {
 		_alert_selection->FindItem("<none>")->SetMarked(true);
@@ -214,7 +214,7 @@ void SoundPreferencesView::AttachedToWindow() {
 	rect.bottom = rect.top + 18.0;
 
 	// groupchat message sounds?
-	_groupchat_sounds = new BCheckBox(rect, NULL, "Exclude groupchat from message sound events", NULL);
+	_groupchat_sounds = new BCheckBox(rect, NULL, "Exclude groupchat from message sound events.", NULL);
 	_groupchat_sounds->SetValue(BlabberSettings::Instance()->Tag("exclude-groupchat-sounds"));
 	
 	// children

--- a/jabber/TransportPreferencesView.cpp
+++ b/jabber/TransportPreferencesView.cpp
@@ -40,7 +40,7 @@ void TransportPreferencesView::AttachedToWindow() {
 	// box frame
 	rect.InsetBy(5.0, 5.0);
 	_surrounding = new BBox(rect, NULL, B_FOLLOW_ALL);
-	_surrounding->SetLabel("External Chat Systems");
+	_surrounding->SetLabel("External chat systems");
 
 	rect = _surrounding->Bounds();
 
@@ -52,7 +52,7 @@ void TransportPreferencesView::AttachedToWindow() {
 	// transport selection
 	_agent_entries = new BPopUpMenu("<select a service>");
 
-	_agent_list = new BMenuField(rect, "agent_registrations", "Online Service: ", _agent_entries);
+	_agent_list = new BMenuField(rect, "agent_registrations", "Online service: ", _agent_entries);
 
 	// username/password fields
 	rect.OffsetBy(0.0, 35.0);
@@ -96,7 +96,7 @@ void TransportPreferencesView::AttachedToWindow() {
 
 	rect.OffsetBy(0.0, 23.0);
 
-	_unregister = new BButton(rect, "register", "UnRegister", new BMessage(UNREGISTER_TRANSPORT));
+	_unregister = new BButton(rect, "register", "Unregister", new BMessage(UNREGISTER_TRANSPORT));
 	_unregister->SetTarget(this);
 	_unregister->SetEnabled(false);
 
@@ -124,7 +124,7 @@ void TransportPreferencesView::AttachedToWindow() {
 	enter_note->MakeEditable(false);
 	enter_note->MakeSelectable(false);
 	enter_note->SetText("Note: Transports serve as the means by which XMPP "
-		"communicates with external chat systems such as IRC.  They "
+		"communicates with external chat systems such as IRC. They "
 		"are add-on components of the XMPP server you are logged on and "
 		"not part of Renga.");
 
@@ -145,12 +145,12 @@ void TransportPreferencesView::MessageReceived(BMessage *msg) {
 		case REGISTER_TRANSPORT: {
 			if (agents->GetAgentByService(_curr_transport)) {
 				if (strlen(_username->Text()) == 0) {
-					ModalAlertFactory::Alert("You must enter a username.", "Doh!");
+					ModalAlertFactory::Alert("You must enter a username.", "OK");
 					break;
 				}
 
 				if (strlen(_password->Text()) == 0) {
-					ModalAlertFactory::Alert("You must enter a password.", "Doh!");
+					ModalAlertFactory::Alert("You must enter a password.", "OK");
 					break;
 				}
 

--- a/ui/AddBuddyWindow.cpp
+++ b/ui/AddBuddyWindow.cpp
@@ -49,12 +49,12 @@ static const char* sXMPPHelpText = "Please enter a JID of the form username@serv
 static const char* sIRCHelpText  = "Please enter the user's IRC nickname and server (e.g., haikulover%irc.oftc.net).";
 
 AddBuddyWindow::AddBuddyWindow(BRect rect)
-	: BWindow(rect, "Add a Buddy", B_TITLED_WINDOW,
+	: BWindow(rect, "Add a buddy", B_TITLED_WINDOW,
 		B_AUTO_UPDATE_SIZE_LIMITS | B_NOT_ZOOMABLE)
 {
 	fNickName = new BTextControl("nickName", "Nickname:", "", NULL);
 
-	fServiceSelection = new BOptionPopUp("Service Selection", "Online service",
+	fServiceSelection = new BOptionPopUp("Service Selection", "Online service:",
 		new BMessage(kOptionChanged));
 	fServiceSelection->AddOption("XMPP", kXMPPSelected);
 	fServiceSelection->AddOption("IRC", kIRCSelected);
@@ -73,7 +73,7 @@ AddBuddyWindow::AddBuddyWindow(BRect rect)
 	kOkButton->MakeDefault(true);
 	kOkButton->SetTarget(this);
 
-	kOkButton->SetLabel("Add Buddy");
+	kOkButton->SetLabel("Add buddy");
 
 	// add GUI components to BView
 	SetLayout(new BGridLayout());
@@ -172,7 +172,7 @@ void AddBuddyWindow::AddNewUser() {
 	JRoster::Instance()->Lock();
 	if (JRoster::Instance()->FindUser(JRoster::COMPLETE_HANDLE, fHandle->Text())) {
 		sprintf(buffer, "%s already exists in your buddy list.  Please choose another so you won't get confused.", fHandle->Text());
-		ModalAlertFactory::Alert(buffer, "Good Idea!");
+		ModalAlertFactory::Alert(buffer, "OK");
 		fHandle->MakeFocus(true);
 		fHandle->MarkAsInvalid(true);
 

--- a/ui/BuddyInfoWindow.cpp
+++ b/ui/BuddyInfoWindow.cpp
@@ -19,7 +19,7 @@
 #include "../jabber/Messages.h"
 
 BuddyInfoWindow::BuddyInfoWindow(UserID *querying_user)
-	: BWindow(BRect(0, 0, 0, 0), "Buddy Information", B_TITLED_WINDOW,
+	: BWindow(BRect(0, 0, 0, 0), "Buddy information", B_TITLED_WINDOW,
 		B_NOT_RESIZABLE | B_NOT_ZOOMABLE | B_AUTO_UPDATE_SIZE_LIMITS)
 	, fJID(querying_user->Handle().c_str())
 {
@@ -44,7 +44,7 @@ BuddyInfoWindow::BuddyInfoWindow(UserID *querying_user)
 	}
 
 	if (!querying_user->MoreExactOnlineStatus().empty()) {
-		status_label = new BStringView(NULL, "Personalized Status:");
+		status_label = new BStringView(NULL, "Personalized status:");
 		status_name  = new BStringView(NULL, querying_user->MoreExactOnlineStatus().c_str());
 
 		surrounding->GridLayout()->AddView(status_label, 0, 1);
@@ -52,16 +52,16 @@ BuddyInfoWindow::BuddyInfoWindow(UserID *querying_user)
 	}
 
 	if (!querying_user->ExactOnlineStatus().empty()) {
-		realstatus_label = new BStringView(NULL, "Official Status:");
+		realstatus_label = new BStringView(NULL, "Official status:");
 
 		if (querying_user->ExactOnlineStatus() == "xa") {
-			realstatus_name  = new BStringView(NULL, "Extended Away");
+			realstatus_name  = new BStringView(NULL, "Extended away");
 		} else if (querying_user->ExactOnlineStatus() == "away") {
 			realstatus_name  = new BStringView(NULL, "Away");
 		} else if (querying_user->ExactOnlineStatus() == "chat") {
-			realstatus_name  = new BStringView(NULL, "Available for Chat");
+			realstatus_name  = new BStringView(NULL, "Available for chat");
 		} else if (querying_user->ExactOnlineStatus() == "dnd") {
-			realstatus_name  = new BStringView(NULL, "Do Not Disturb");
+			realstatus_name  = new BStringView(NULL, "Do not disturb");
 		}
 
 		surrounding->GridLayout()->AddView(realstatus_label, 0, 2);

--- a/ui/ChangeNameWindow.cpp
+++ b/ui/ChangeNameWindow.cpp
@@ -19,7 +19,7 @@
 #include "../jabber/TalkManager.h"
 
 ChangeNameWindow::ChangeNameWindow(const gloox::JID& changing_user, BString oldName)
-	: BWindow(BRect(0, 0, 100, 100), "Change Buddy Name", B_TITLED_WINDOW,
+	: BWindow(BRect(0, 0, 100, 100), "Change buddy name", B_TITLED_WINDOW,
 		B_NOT_RESIZABLE | B_NOT_ZOOMABLE | B_AUTO_UPDATE_SIZE_LIMITS),
 	_changing_user(changing_user)
 {
@@ -38,10 +38,10 @@ ChangeNameWindow::ChangeNameWindow(const gloox::JID& changing_user, BString oldN
 		_handle->SetText("somebody@jabber.org");
 	}
 
-	BButton *cancel = new BButton("cancel", "Nevermind", new BMessage(JAB_CANCEL));
+	BButton *cancel = new BButton("cancel", "Cancel", new BMessage(JAB_CANCEL));
 	cancel->SetTarget(this);
 
-	BButton *ok = new BButton("ok", "Change Name", new BMessage(JAB_OK));
+	BButton *ok = new BButton("ok", "Change nickname", new BMessage(JAB_OK));
 	ok->MakeDefault(true);
 	ok->SetTarget(this);
 
@@ -72,7 +72,7 @@ void ChangeNameWindow::MessageReceived(BMessage *msg) {
 		//// JAB_OK
 		case JAB_OK: {
 			if (!strcmp(_handle->Text(), "")) {
-				ModalAlertFactory::Alert("You cannot erase your buddy's name.  If you're trying to remove this buddy, please use the \"Remove Buddy\" item on the user.", "Oops!");
+				ModalAlertFactory::Alert("You cannot erase your buddy's name.  If you're trying to remove this buddy, please use the \"Remove buddy\" item on the user.", "OK");
 				_handle->MakeFocus(true);
 
 				return;

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -680,11 +680,11 @@ void BlabberMainWindow::MenusBeginning() {
 
 		_user_info_item->SetEnabled(true);
 	} else {
-		sprintf(buffer, "Edit Buddy");
+		sprintf(buffer, "Edit buddy");
 		_change_buddy_item->SetLabel(buffer);
 		_change_buddy_item->SetEnabled(false);
 
-		sprintf(buffer, "Remove Buddy");
+		sprintf(buffer, "Remove buddy");
 		_remove_buddy_item->SetLabel(buffer);
 		_remove_buddy_item->SetEnabled(false);
 
@@ -731,15 +731,15 @@ BlabberMainWindow::BlabberMainWindow(BRect frame)
 	BMenuBar* menubar = new BMenuBar("menubar");
 
 	// FILE MENU
-	BMenu* file_menu = new BMenu("Window");
+	BMenu* file_menu = new BMenu("App");
 
-		_disconnect_item = new BMenuItem("Log Out", new BMessage(JAB_DISCONNECT));
+		_disconnect_item = new BMenuItem("Log out", new BMessage(JAB_DISCONNECT));
 
 		_about_item      = new BMenuItem("About Renga" B_UTF8_ELLIPSIS, new BMessage(B_ABOUT_REQUESTED));
 
 		_quit_item = new BMenuItem("Quit", new BMessage(JAB_QUIT));
 		_quit_item->SetShortcut('Q', 0);
-		_preferences_item = new BMenuItem("Preferences" B_UTF8_ELLIPSIS, new BMessage(JAB_PREFERENCES));
+		_preferences_item = new BMenuItem("Settings" B_UTF8_ELLIPSIS, new BMessage(JAB_PREFERENCES));
 		_preferences_item->SetShortcut(',', 0);
 
 	file_menu->AddItem(_preferences_item);
@@ -752,16 +752,16 @@ BlabberMainWindow::BlabberMainWindow(BRect frame)
 	// EDIT MENU
 	BMenu* edit_menu = new BMenu("Buddy");
 
-		_add_buddy_item = new BMenuItem("Add New Buddy", new BMessage(JAB_OPEN_ADD_BUDDY_WINDOW));
+		_add_buddy_item = new BMenuItem("Add new buddy", new BMessage(JAB_OPEN_ADD_BUDDY_WINDOW));
 		_add_buddy_item->SetShortcut('N', 0);
 
-		_change_buddy_item = new BMenuItem("Edit Buddy", new BMessage(JAB_OPEN_EDIT_BUDDY_WINDOW));
+		_change_buddy_item = new BMenuItem("Edit buddy", new BMessage(JAB_OPEN_EDIT_BUDDY_WINDOW));
 		_change_buddy_item->SetShortcut('E', 0);
 
-		_remove_buddy_item = new BMenuItem("Remove Buddy", new BMessage(JAB_REMOVE_BUDDY));
+		_remove_buddy_item = new BMenuItem("Remove buddy", new BMessage(JAB_REMOVE_BUDDY));
 		_remove_buddy_item->SetShortcut('T', 0);
 
-		_user_info_item = new BMenuItem("Get Buddy Info", new BMessage(JAB_USER_INFO));
+		_user_info_item = new BMenuItem("Get buddy info", new BMessage(JAB_USER_INFO));
 		_user_info_item->SetShortcut('G', 0);
 
 	edit_menu->AddItem(_add_buddy_item);
@@ -774,16 +774,16 @@ BlabberMainWindow::BlabberMainWindow(BRect frame)
 	// STATUS MENU
 	BMenu* status_menu = new BMenu("Status");
 
-		_chat_item = new BMenuItem("I'm available for chat.", new BMessage(BLAB_AVAILABLE_FOR_CHAT));
-		_away_item = new BMenuItem("I will be away temporarily.", new BMessage(BLAB_AWAY_TEMPORARILY));
-		_dnd_item = new BMenuItem("Do not disturb me.", new BMessage(BLAB_DO_NOT_DISTURB));
-		_xa_item = new BMenuItem("I will be away for an extended time period.", new BMessage(BLAB_AWAY_EXTENDED));
-		_school_item = new BMenuItem("Off to School", new BMessage(BLAB_SCHOOL));
-		_work_item = new BMenuItem("Busy at Work", new BMessage(BLAB_WORK));
+		_chat_item = new BMenuItem("I'm available for chat", new BMessage(BLAB_AVAILABLE_FOR_CHAT));
+		_away_item = new BMenuItem("I will be away temporarily", new BMessage(BLAB_AWAY_TEMPORARILY));
+		_dnd_item = new BMenuItem("Do not disturb me", new BMessage(BLAB_DO_NOT_DISTURB));
+		_xa_item = new BMenuItem("I will be away for an extended time period", new BMessage(BLAB_AWAY_EXTENDED));
+		_school_item = new BMenuItem("Off to school", new BMessage(BLAB_SCHOOL));
+		_work_item = new BMenuItem("Busy at work", new BMessage(BLAB_WORK));
 		_lunch_item = new BMenuItem("Lunch", new BMessage(BLAB_LUNCH));
 		_dinner_item = new BMenuItem("Dinner", new BMessage(BLAB_DINNER));
 		_sleep_item = new BMenuItem("Sleeping", new BMessage(BLAB_SLEEP));
-		_custom_item = new BMenuItem("Custom...", new BMessage(BLAB_CUSTOM_STATUS));
+		_custom_item = new BMenuItem("Custom" B_UTF8_ELLIPSIS, new BMessage(BLAB_CUSTOM_STATUS));
 
 	status_menu->AddItem(_chat_item);
 	status_menu->AddSeparatorItem();
@@ -807,18 +807,18 @@ BlabberMainWindow::BlabberMainWindow(BRect frame)
 	// TALK MENU
 	BMenu* talk_menu = new BMenu("Talk");
 
-		BMenuItem* rotate_chat_forward_item = new BMenuItem("Rotate Chat Forward", new BMessage(JAB_ROTATE_CHAT_FORWARD));
+		BMenuItem* rotate_chat_forward_item = new BMenuItem("Rotate chat forward", new BMessage(JAB_ROTATE_CHAT_FORWARD));
 		rotate_chat_forward_item->SetShortcut(B_UP_ARROW, B_SHIFT_KEY);
 
-		BMenuItem* rotate_chat_backward_item = new BMenuItem("Rotate Chat Backward", new BMessage(JAB_ROTATE_CHAT_BACKWARD));
+		BMenuItem* rotate_chat_backward_item = new BMenuItem("Rotate chat backward", new BMessage(JAB_ROTATE_CHAT_BACKWARD));
 		rotate_chat_backward_item->SetShortcut(B_DOWN_ARROW, B_SHIFT_KEY);
 
-		_send_message_item = new BMenuItem("Send Message...", new BMessage(JAB_OPEN_NEW_MESSAGE));
+		_send_message_item = new BMenuItem("Send message" B_UTF8_ELLIPSIS, new BMessage(JAB_OPEN_NEW_MESSAGE));
 		_send_message_item->SetShortcut('M', 0);
 
-		_send_chat_item = new BMenuItem("Start Chat...", new BMessage(JAB_OPEN_NEW_CHAT));
+		_send_chat_item = new BMenuItem("Start chat" B_UTF8_ELLIPSIS, new BMessage(JAB_OPEN_NEW_CHAT));
 
-		_send_groupchat_item = new BMenuItem("Start Group Chat...", new BMessage(JAB_OPEN_NEW_GROUP_CHAT));
+		_send_groupchat_item = new BMenuItem("Start group chat" B_UTF8_ELLIPSIS, new BMessage(JAB_OPEN_NEW_GROUP_CHAT));
 
 	talk_menu->AddItem(rotate_chat_forward_item);
 	talk_menu->AddItem(rotate_chat_backward_item);
@@ -831,7 +831,7 @@ BlabberMainWindow::BlabberMainWindow(BRect frame)
 	// HELP MENU
 	BMenu* help_menu = new BMenu("Help");
 
-	BMenuItem* user_guide_item = new BMenuItem("Renga Manual", new BMessage(JAB_USER_GUIDE));
+	BMenuItem* user_guide_item = new BMenuItem("Renga manual", new BMessage(JAB_USER_GUIDE));
 	BMenuItem* faq_item = new BMenuItem("Renga FAQ", new BMessage(JAB_FAQ));
 
 	help_menu->AddItem(user_guide_item);
@@ -971,7 +971,7 @@ BlabberMainWindow::BlabberMainWindow(BRect frame)
 bool BlabberMainWindow::ValidateLogin() {
 	// existance of username
 	if (!strcmp(_login_username->Text(), "")) {
-		ModalAlertFactory::Alert("Wait, you haven't specified your Jabber ID yet.\n(e.g. haikuFan@jabber.org)", "Doh!", NULL, NULL, B_WIDTH_FROM_LABEL, B_STOP_ALERT);
+		ModalAlertFactory::Alert("Wait, you haven't specified your Jabber ID yet.\n(e.g. haikuFan@jabber.org)", "OK", NULL, NULL, B_WIDTH_FROM_LABEL, B_STOP_ALERT);
 		_login_username->MakeFocus(true);
 
 		return false;
@@ -981,7 +981,7 @@ bool BlabberMainWindow::ValidateLogin() {
 	std::string validate = UserID::WhyNotValidJabberHandle(_login_username->Text());
 	if (validate.size()) {
 		BString buffer;
-		buffer.SetToFormat("The Jabber ID you specified must not be yours because it's invalid for the following reason:\n\n%s\n\nIf you can't remember it, it's OK to create a new one by checking the \"Create a new Jabber Account!\" box.", validate.c_str());
+		buffer.SetToFormat("The Jabber ID you specified must not be yours, because it's invalid for the following reason:\n\n%s\n\nIf you can't remember it, it's OK to create a new one by checking the \"Create a new Jabber account!\" box.", validate.c_str());
 
 		ModalAlertFactory::Alert(buffer, "OK", NULL, NULL,
 			B_WIDTH_FROM_LABEL, B_STOP_ALERT);
@@ -998,7 +998,7 @@ bool BlabberMainWindow::ValidateLogin() {
 		sprintf(buffer, "You must specify a password so I can make sure it's you, %s.",
 			username.username().c_str());
 
-		ModalAlertFactory::Alert(buffer, "Sorry!", NULL, NULL,
+		ModalAlertFactory::Alert(buffer, "OK", NULL, NULL,
 			B_WIDTH_FROM_LABEL, B_STOP_ALERT);
 		_login_password->MakeFocus(true);
 

--- a/ui/RegisterAccountWindow.cpp
+++ b/ui/RegisterAccountWindow.cpp
@@ -85,10 +85,10 @@ RegisterAccountWindow::RegisterAccountWindow(BHandler* target __attribute__((unu
 	BTextView* agree = new BTextView("agree");
 	agree->SetText("In order to find a nearby server, the application will now "
 		"attempt to geolocalize you. A list of wifi networks within reach of "
-		"your computer will be sent to Mozilla Location Services. The "
-		"resulting estimated latitude and longitude will be sent to Geonames "
-		"to deduce the country you are in. If you don't want this to happen, "
-		"you will have to pick a server yourself.");
+		"your computer will be sent to Mozilla Location Services.\n"
+		"The resulting estimated latitude and longitude will be sent to Geonames "
+		"to deduce the country you are in.\n\n"
+		"If you don't want this to happen, you will have to pick a server yourself.");
 	float charSize = agree->StringWidth("W");
 	agree->SetExplicitMinSize(BSize(charSize * 30, charSize * 7));
 	agree->MakeEditable(false);
@@ -96,8 +96,8 @@ RegisterAccountWindow::RegisterAccountWindow(BHandler* target __attribute__((unu
 	agree->SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
 	// TODO add hyperlinks to MLS and Geonames
 	
-	BButton* yes = new BButton("yes", "Yes, please", new BMessage(kGeolocalize));
-	BButton* no = new BButton("no", "No thanks!", new BMessage(kShowServerList));
+	BButton* yes = new BButton("yes", "Geolocate", new BMessage(kGeolocalize));
+	BButton* no = new BButton("no", "Set manually", new BMessage(kShowServerList));
 
 	BLayoutBuilder::Group<>(card0)
 		.SetInsets(B_USE_WINDOW_INSETS)
@@ -115,10 +115,10 @@ RegisterAccountWindow::RegisterAccountWindow(BHandler* target __attribute__((unu
 	AddChild(card1);
 
 	fWelcome = new BTextView("welcome");
-	fWelcome->SetText("Welcome to the XMPP network! We have chosen a server for "
-		"you, but you can select another one if you prefer to. The server name "
-		"will be part of your XMPP identifier, so you may pick one with a "
-		"short and catchy name.");
+	fWelcome->SetText("Welcome to the XMPP network!\n"
+		"We have chosen a server for you, but you can select another if you "
+		"want to. The server name will be part of your XMPP identifier, so you "
+		"may want to pick one with a short and catchy name.");
 	fWelcome->SetExplicitMinSize(BSize(charSize * 30, charSize * 7));
 	fWelcome->MakeEditable(false);
 	fWelcome->MakeSelectable(false);
@@ -155,7 +155,7 @@ RegisterAccountWindow::RegisterAccountWindow(BHandler* target __attribute__((unu
 	BGroupView* card2 = new BGroupView(B_VERTICAL);
 	AddChild(card2);
 
-	fWaitingMessage = new BStringView("wait", "Please wait, connecting to server…");
+	fWaitingMessage = new BStringView("wait", "Please wait, connecting to server" B_UTF8_ELLIPSIS);
 	// TODO add a BarberPole or throbber something
 
 	BLayoutBuilder::Group<>(card2)
@@ -182,7 +182,7 @@ RegisterAccountWindow::RegisterAccountWindow(BHandler* target __attribute__((unu
 	fPostalAddress = new BTextControl("Postal address", "", NULL);
 	fCity = new BTextControl("City", "", NULL);
 	fState = new BTextControl("State", "", NULL);
-	fZip = new BTextControl("ZIP Code", "", NULL);
+	fZip = new BTextControl("ZIP code", "", NULL);
 	fPhoneNumber = new BTextControl("Phone number", "", NULL);
 	fUrl = new BTextControl("Homepage", "", NULL);
 	fDate = new BTextControl("Date", "", NULL);
@@ -325,13 +325,13 @@ RegisterAccountWindow::MessageReceived(BMessage* message)
 				case kConnect:
 				{
 					// TODO request registration fields here instead of in GlooxHandler
-					fWaitingMessage->SetText("Setting up secure connection…");
+					fWaitingMessage->SetText("Setting up secure connection" B_UTF8_ELLIPSIS);
 					break;
 				}
 				case kTLSConnect:
 				{
 					// TODO confirm TLS certificate, when gloox handler supports that
-					fWaitingMessage->SetText("Getting registration form from server…");
+					fWaitingMessage->SetText("Getting registration form from server" B_UTF8_ELLIPSIS);
 					break;
 				}
 				case kDisconnect:


### PR DESCRIPTION
* Sentence-casing of all GUI strings.
* Make most of the standard button labels less whimsical,
  e.g. use OK and Cancel.
* Remove full-stops from menu items and button labels. Those
  look just wrong.
* Replace "..." with B_UTF8_ELLIPSIS
* Rename menu "Windows" to "App"
* Rename "Preferences" to "Settings", as that's the usual
  terminology in Haiku apps, leaving "Preferences" for the
  actual pref panels in the similar named Deskbar menu.