### PR TITLE
Activate already open windows

### DIFF
--- a/jabber/PreferencesWindow.cpp
+++ b/jabber/PreferencesWindow.cpp
@@ -27,9 +27,10 @@
 PreferencesWindow *PreferencesWindow::_instance = NULL;
 
 PreferencesWindow *PreferencesWindow::Instance() {
-	if (_instance == NULL) {
+	if (_instance == NULL)
 		_instance = new PreferencesWindow();
-	}
+	else if (!_instance->IsActive())
+		_instance->Activate();
 
 	return _instance;
 }

--- a/ui/AboutWindow.cpp
+++ b/ui/AboutWindow.cpp
@@ -15,7 +15,8 @@ AboutWindow *AboutWindow::Instance() {
 	if (_instance == NULL) {
 		// create window singleton
 		_instance = new AboutWindow();
-	}
+	} else if (!_instance->IsActive())
+		_instance->Activate();
 
 	return _instance;
 }

--- a/ui/AddBuddyWindow.cpp
+++ b/ui/AddBuddyWindow.cpp
@@ -32,6 +32,8 @@ AddBuddyWindow *AddBuddyWindow::fInstance = NULL;
 AddBuddyWindow *AddBuddyWindow::Instance(BRect frame) {
 	if (fInstance == NULL)
 		fInstance = new AddBuddyWindow(frame);
+	else if (!fInstance->IsActive())
+		fInstance->Activate();
 
 	return fInstance;
 }


### PR DESCRIPTION
To avoid losing already open settings, about and addbuddy
windows behind the main window, Activate() them to bring them
to the front.